### PR TITLE
fix(UART_ReceptionToIdle_CircularDMA): wrap old_pos to fix silent data loss

### DIFF
--- a/Projects/STM32446E-Nucleo/Examples/UART/UART_ReceptionToIdle_CircularDMA/Src/main.c
+++ b/Projects/STM32446E-Nucleo/Examples/UART/UART_ReceptionToIdle_CircularDMA/Src/main.c
@@ -392,8 +392,11 @@ void HAL_UARTEx_RxEventCallback(UART_HandleTypeDef *huart, uint16_t Size)
     pBufferReadyForReception = ptemp;
   }
   /* Update old_pos as new reference of position in User Rx buffer that
-     indicates position to which data have been processed */
-  old_pos = Size;
+     indicates position to which data have been processed.
+     Size can be equal to RX_BUFFER_SIZE (not wrapped to 0) when the
+     Transfer Complete event reports a full circular buffer, so it must be
+     wrapped here to stay a valid index into aRXBufferUser. */
+  old_pos = Size % RX_BUFFER_SIZE;
 
 }
 


### PR DESCRIPTION
Relates to #196 (closed for inactivity, but the underlying issue is still present in current `main.c`).

### Problem

In `HAL_UARTEx_RxEventCallback()`, `old_pos` tracks the last-processed position in the circular DMA Rx buffer, compared against the HAL-reported `Size` to detect new data:

```c
if (Size != old_pos)
{
  ...
}
old_pos = Size;
```

On a Transfer Complete event (buffer fills up exactly to `RX_BUFFER_SIZE`), the HAL reports `Size == huart->RxXferSize == RX_BUFFER_SIZE`, **not** a wrapped `0`. This is confirmed in `Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_uart.c`'s `UART_DMAReceiveCplt()`:

```c
if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
{
  ...
  HAL_UARTEx_RxEventCallback(huart, huart->RxXferSize);
}
```

Since `old_pos = Size;` stores this unwrapped, after one full-buffer cycle `old_pos` is left at `RX_BUFFER_SIZE`. On every subsequent full-buffer Transfer Complete event, `Size == old_pos == RX_BUFFER_SIZE`, so `Size != old_pos` spuriously evaluates false and an entire buffer's worth of newly received UART data is silently dropped — `UserDataTreatment()` is never called for it.

This matches the original report in #196: "old_pos==RX_BUFFER_SIZE Size==RX_BUFFER_SIZE ... will break condition."

### Fix

Wrap `old_pos` with `% RX_BUFFER_SIZE` so it stays a valid index into `aRXBufferUser`, matching the actual wrapped position (this is also the fix originally suggested in #196).

### Test plan

No hardware on hand to reproduce end-to-end, so I verified with a standalone C reproduction of the callback's exact state-machine logic (comparing before/after over 3 consecutive full-buffer Transfer Complete events, each reporting `Size == RX_BUFFER_SIZE`):

- Before the fix: `UserDataTreatment()` is called only once (10/30 bytes processed) — cycles 2 and 3 are silently dropped, exactly reproducing the reported bug.
- After the fix: `UserDataTreatment()` is called on all 3 cycles (30/30 bytes processed).
- Partial (non-full-buffer) receptions are unaffected, since `Size % RX_BUFFER_SIZE == Size` when `Size < RX_BUFFER_SIZE`.

### Disclosure

Generative AI (Claude) was used to help investigate this issue, implement, and verify this fix. All changes were reviewed by me before submission.
